### PR TITLE
LDP-1526: Make project use php 8.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=8.1",
         "ext-json": "*",
         "consolidation/robo": "^3",
         "diffywebsite/diffy-php": "1.x-dev",
@@ -36,7 +36,7 @@
     "scripts": {
         "phar:install-tools": [
             "mkdir -p tools",
-            "curl -L https://github.com/humbug/box/releases/download/3.9.1/box.phar -o tools/box",
+            "curl -L https://github.com/humbug/box/releases/download/4.0.2/box.phar -o tools/box",
             "chmod +x tools/box"
         ],
         "phar:build": "env PATH=tools:$PATH box compile",


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Has tests?    | no
| BC breaks?    | yes    
| Deprecations? | no

### Summary
PHP version requirement bumped to 8.1. 
humbug/box tool version updated to the php 8.1 compatible one - 4.0.2.

### Description
Any additional information.
