### PR TITLE
Add a bin entry so requiring via composer will add a bin script.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "g1a/composer-test-scenarios": "^2",
         "squizlabs/php_codesniffer": "^2.8"
     },
+    "bin": [
+        "diffy"
+    ],
     "scripts": {
         "phar:install-tools": [
             "mkdir -p tools",


### PR DESCRIPTION

### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes? (maybe?)
| New feature?  | don't think so... 🤷🏼 
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Add a bin entry so requiring via composer will add a bin script.

### Description
See https://getcomposer.org/doc/articles/vendor-binaries.md

A colleague of mine was trying to include the cli in our project so we could easily run it and ran into an issue executing. Checking the composer.json I found the bin entry missing. This should make it easier for folks to use the project as a dependency of their own projects.

See [drush](https://github.com/drush-ops/drush/blob/11.x/composer.json#L22) as an example of this done on other projects.

If there is a reason this isn't done that I am just not familiar with, feel free to close 👍🏼 