### PR TITLE
Fix setScreenshotBaseline

### DIFF
--- a/src/Commands/ScreenshotCommand.php
+++ b/src/Commands/ScreenshotCommand.php
@@ -190,15 +190,6 @@ class ScreenshotCommand extends Tasks
         Diffy::setApiKey($apiKey);
 
         Screenshot::setBaselineSet($projectId, $screenshotId);
-        $this->getIO()->writeln('Baseline for project <info>' . $projectId . '</info> has been updated.');
-    }
-
-    protected function getIO(): SymfonyStyle
-    {
-        if (!$this->io) {
-            $this->io = new SymfonyStyle($this->input(), $this->output());
-        }
-
-        return $this->io;
+        $this->io()->write(sprintf('Baseline for project %d has been updated.', $projectId));
     }
 }


### PR DESCRIPTION
### Overview
add check for the api key in the setScreenshotBaseline function. Add getIO to ScreenshotCommand.php to make last line from setScreenshotBaseline command work.

This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | yes/no
| BC breaks?    | no     
| Deprecations? | yes/no 

### Summary
Short overview of what changed.

### Description
Any additional information.
