### PR TITLE
Fix PHP Warning:  Undefined array key "sharedUrl"

### DIFF
--- a/src/Commands/DiffCommand.php
+++ b/src/Commands/DiffCommand.php
@@ -234,7 +234,7 @@ class DiffCommand extends Tasks
                     'state' => Diff::getStateName($diff['state']),
                     'jobs' => $diff['status']['jobs'],
                     'estimate' => ($diff['status']['jobs'] > 0) ? $diff['status']['estimate'] : 'Finished',
-                    'sharedUrl' => $diff['sharedUrl'],
+                    'sharedUrl' => $diff['sharedUrl'] ?? NULL,
                 ];
             }
         }


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Fix php warning

### Description
Just a quick small thing. Since at least 6 months (I don't know if longer), our automated build/test logs are showing
```
Running Diffy for ***

 [OK] Key is validated and saved                                                

PHP Warning:  Undefined array key "sharedUrl" in phar:///app/tests/vrt/diffy.phar/src/Commands/DiffCommand.php on line 237
PHP Warning:  Undefined array key "sharedUrl" in phar:///app/tests/vrt/diffy.phar/src/Commands/DiffCommand.php on line 237
PHP Warning:  Undefined array key "sharedUrl" in phar:///app/tests/vrt/diffy.phar/src/Commands/DiffCommand.php on line 237
PHP Warning:  Undefined array key "sharedUrl" in phar:///app/tests/vrt/diffy.phar/src/Commands/DiffCommand.php on line 237
[.... times a hundred... ]
PHP Warning:  Undefined array key "sharedUrl" in phar:///app/tests/vrt/diffy.phar/src/Commands/DiffCommand.php on line 237
PHP Warning:  Undefined array key "sharedUrl" in phar:///app/tests/vrt/diffy.phar/src/Commands/DiffCommand.php on line 237
Diffy check completed without any diffs reported.
Diffy reported status (Diff ID, Num of diffs, Status): ****** 0 Completed 
Please visit https://app.diffy.website/#/diffs/****** for diff results.
```
This should suppress teh warning:
* since the 'input' is coming from a web request, it should apparently be 'legal/expoected' that sharedUrl can be unset
* value is kept at NULL to introduce no changes. 'output' is a Robo io ::table() method, I haven't checked it, but it can apparently handle NULLs because nothing wrong is being reported.